### PR TITLE
refact: usa DateTime na competência

### DIFF
--- a/specs/MeuPonto.Specs.Web/Modules/HomePageDriver.cs
+++ b/specs/MeuPonto.Specs.Web/Modules/HomePageDriver.cs
@@ -58,8 +58,7 @@ public class HomePageDriver : HomeInterface
         var perfil = folhaAberta.EQualificadaPelo();
 
         form.GetSelect("PerfilId").GetOption(perfil.Nome).IsSelected = true;
-        form.GetInput("CompetenciaAno").Value = folhaAberta.Competencia.Value.ToString("yyyy");
-        form.GetSelect("CompetenciaMes").Value = folhaAberta.Competencia.Value.ToString("MM");
+        form.GetInput("Competencia").ValueAsDate = folhaAberta.Competencia;
 
         var submitButton = form.GetSubmitButton();
 

--- a/specs/MeuPonto.Specs.Web/Modules/Pontos/Folhas/GestaoFolhasPageDriver.cs
+++ b/specs/MeuPonto.Specs.Web/Modules/Pontos/Folhas/GestaoFolhasPageDriver.cs
@@ -55,8 +55,7 @@ public class GestaoFolhasPageDriver : GestaoFolhasInterface
         //var competencia = folha.Competencia.Value.ToString("yyyy-MM-dd\\THH:mm:ss");
 
         form.GetSelect("Folha.PerfilId").GetOption(perfil.Nome).IsSelected = true;
-        form.GetInput("CompetenciaAno").Value = folha.Competencia.Value.Year.ToString();
-        form.GetSelect("CompetenciaMes").Value = folha.Competencia.Value.Month.ToString();
+        form.GetInput("Folha.Competencia").ValueAsDate = folha.Competencia;
         form.GetTextArea("Folha.Observacao").Value = folha.Observacao;
 
         var confirmarCompetenciaButton = form.GetSubmitButton("button[value='ConfirmarCompetencia']");
@@ -117,7 +116,7 @@ public class GestaoFolhasPageDriver : GestaoFolhasInterface
             {
                 Nome = dl.GetDataListItem("Perfil").GetString(),
             },
-            Competencia = DateTime.ParseExact(dl.GetDataListItem("Competencia").GetString().Substring(0, 7), "yyyy/MM", CultureInfo.InvariantCulture),
+            Competencia = DateTime.ParseExact(dl.GetDataListItem("Competencia").GetString(), "y", CultureInfo.CurrentCulture),
             StatusId = (StatusEnum)Enum.Parse(typeof(StatusEnum), dl.GetDataListItem("Status").GetString()),
             Observacao = dl.GetDataListItem("Observacao").GetString(),
             ApuracaoMensal = new ApuracaoMensal

--- a/specs/MeuPonto.Specs/Modules/Pontos/Comprovantes/BackupComprovantesStepDefinitions.cs
+++ b/specs/MeuPonto.Specs/Modules/Pontos/Comprovantes/BackupComprovantesStepDefinitions.cs
@@ -1,6 +1,5 @@
 using MeuPonto.Data;
 using MeuPonto.Modules.Perfis;
-using MeuPonto.Modules.Trabalhadores;
 
 namespace MeuPonto.Modules.Pontos.Comprovantes;
 

--- a/specs/MeuPonto.Specs/Modules/Pontos/Folhas/GestaoFolhasStepDefinitions.cs
+++ b/specs/MeuPonto.Specs/Modules/Pontos/Folhas/GestaoFolhasStepDefinitions.cs
@@ -1,7 +1,6 @@
 using MeuPonto.Data;
 using MeuPonto.Helpers;
 using MeuPonto.Modules.Perfis;
-using MeuPonto.Modules.Trabalhadores;
 using System.ComponentModel;
 
 namespace MeuPonto.Modules.Pontos.Folhas;

--- a/src/MeuPonto.DocumentModel/Modules/Pontos/Folhas/Folha.cs
+++ b/src/MeuPonto.DocumentModel/Modules/Pontos/Folhas/Folha.cs
@@ -15,7 +15,7 @@ public class Folha : DocumentEntity, Concepts.Folha
 
     [Required]
     [DisplayName("Competência")]
-    [DisplayFormat(DataFormatString = "{0:yyyy/MM (MMMM)}")]
+    [DisplayFormat(DataFormatString = "{0:y}")]
     public DateTime? Competencia { get; set; }
 
     [Required]

--- a/src/MeuPonto.DocumentModel/Modules/Pontos/Folhas/FolhaFacade.cs
+++ b/src/MeuPonto.DocumentModel/Modules/Pontos/Folhas/FolhaFacade.cs
@@ -2,13 +2,9 @@
 
 public static class FolhaFacade
 {
-    public static void ConfirmarCompetencia(this Folha folha, Perfis.Perfil? perfil, int ano, int mes)
+    public static void ConfirmarCompetencia(this Folha folha, Perfis.Perfil? perfil)
     {
-        folha.ApuracaoMensal.Dias.Clear();
-
-        var competenciaAtual = new DateTime(ano, mes, 1);
-
-        folha.Competencia = competenciaAtual;
+        var competenciaAtual = folha.Competencia.Value;
 
         var competenciaPosterior = competenciaAtual.AddMonths(1);
 

--- a/src/MeuPonto.GlobalTableModel/Modules/Pontos/Folhas/Folha.cs
+++ b/src/MeuPonto.GlobalTableModel/Modules/Pontos/Folhas/Folha.cs
@@ -16,7 +16,7 @@ public class Folha : GlobalTableEntity, Concepts.Folha
 
     [Required]
     [DisplayName("Competência")]
-    [DisplayFormat(DataFormatString = "{0:yyyy/MM (MMMM)}")]
+    [DisplayFormat(DataFormatString = "{0:y}")]
     public DateTime? Competencia { get; set; }
 
     [Required]

--- a/src/MeuPonto.Web/Modules/Index.cshtml
+++ b/src/MeuPonto.Web/Modules/Index.cshtml
@@ -36,25 +36,8 @@
             </div>
             <div action="col-12">
                 <div class="input-group">
-                    <label class="input-group-text">Competência</label>
-                    <label asp-for="CompetenciaAno" class="visually-hidden"></label>
-                    <input asp-for="CompetenciaAno" class="form-control" placeholder="Ano" />
-                    <label asp-for="CompetenciaMes" class="visually-hidden"></label>
-                    <select asp-for="CompetenciaMes" class="form-select">
-                        <option value="" disabled selected>Mês</option>
-                        <option value="1">01 (janeiro)</option>
-                        <option value="2">02 (fevereiro)</option>
-                        <option value="3">03 (março)</option>
-                        <option value="4">04 (abril)</option>
-                        <option value="5">05 (maio)</option>
-                        <option value="6">06 (junho)</option>
-                        <option value="7">07 (julho)</option>
-                        <option value="8">08 (agosto)</option>
-                        <option value="9">09 (setembro)</option>
-                        <option value="10">10 (outubro)</option>
-                        <option value="11">11 (novembro)</option>
-                        <option value="12">12 (dezembro)</option>
-                    </select>
+                    <label asp-for="Competencia" class="input-group-text"></label>
+                    <input asp-for="Competencia" class="form-control" type="month" />
                 </div>
             </div>
             <div class="col-12">

--- a/src/MeuPonto.Web/Modules/Index.cshtml.cs
+++ b/src/MeuPonto.Web/Modules/Index.cshtml.cs
@@ -31,12 +31,8 @@ public class IndexModel : PageModel
     public Guid? PerfilId { get; set; }
 
     [BindProperty(SupportsGet = true)]
-    [DisplayName("Ano")]
-    public int? CompetenciaAno { get; set; }
-
-    [BindProperty(SupportsGet = true)]
-    [DisplayName("Mês")]
-    public int? CompetenciaMes { get; set; }
+    [DisplayName("Competência")]
+    public DateTime? Competencia { get; set; }
 
     public Folha Folha { get; set; }
 
@@ -59,15 +55,13 @@ public class IndexModel : PageModel
 
         var hoje = DateTime.Today;
 
-        if (CompetenciaAno == null || CompetenciaMes == null)
+        if (Competencia == null)
         {
-            CompetenciaAno = hoje.Year;
-
-            CompetenciaMes = hoje.Month;
+            Competencia = hoje;
         }
         else
         {
-            var competencia = new DateTime(CompetenciaAno.Value, CompetenciaMes.Value, 1);
+            var competencia = Competencia;
 
             Folha = await _db.Folhas.FirstOrDefaultAsync(x => true
                 && x.PerfilId == PerfilId

--- a/src/MeuPonto.Web/Modules/Pontos/Comprovantes/Guardar.cshtml.cs
+++ b/src/MeuPonto.Web/Modules/Pontos/Comprovantes/Guardar.cshtml.cs
@@ -1,5 +1,4 @@
 ﻿using MeuPonto.Data;
-using MeuPonto.Modules.Trabalhadores;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.AspNetCore.Mvc.Rendering;

--- a/src/MeuPonto.Web/Modules/Pontos/Folhas/Abrir.cshtml
+++ b/src/MeuPonto.Web/Modules/Pontos/Folhas/Abrir.cshtml
@@ -40,31 +40,13 @@
     </div>
 </div>
 <div class="row mb-3">
-    <span class="col-sm-3 col-form-label">Competência</span>
+    <label asp-for="Folha.Competencia" class="col-sm-3 col-form-label"></label>
     <div class="col-sm-9">
         <div class="input-group">
-            <label asp-for="CompetenciaAno" class="input-group-text"></label>
-            <input asp-for="CompetenciaAno" class="form-control" placeholder="Ano" />
-            <label asp-for="CompetenciaMes" class="input-group-text"></label>
-            <select asp-for="CompetenciaMes" class="form-select">
-                <option value="" disabled selected>Mês</option>
-                <option value="1">01 (janeiro)</option>
-                <option value="2">02 (fevereiro)</option>
-                <option value="3">03 (março)</option>
-                <option value="4">04 (abril)</option>
-                <option value="5">05 (maio)</option>
-                <option value="6">06 (junho)</option>
-                <option value="7">07 (julho)</option>
-                <option value="8">08 (agosto)</option>
-                <option value="9">09 (setembro)</option>
-                <option value="10">10 (outubro)</option>
-                <option value="11">11 (novembro)</option>
-                <option value="12">12 (dezembro)</option>
-            </select>
+            <input asp-for="Folha.Competencia" class="form-control" type="month" />
             <button class="btn btn-outline-secondary" name="command" value="ConfirmarCompetencia">Confirmar</button>
         </div>
-        <span asp-validation-for="CompetenciaAno" class="text-danger"></span>
-        <span asp-validation-for="CompetenciaMes" class="text-danger"></span>
+        <span asp-validation-for="Folha.Competencia" class="text-danger"></span>
     </div>
 </div>
 <div class="row mb-3">

--- a/src/MeuPonto.Web/Modules/Pontos/Folhas/Criar.cshtml
+++ b/src/MeuPonto.Web/Modules/Pontos/Folhas/Criar.cshtml
@@ -40,31 +40,13 @@
     </div>
 </div>
 <div class="row mb-3">
-    <span class="col-sm-3 col-form-label">Competência</span>
+    <label asp-for="Folha.Competencia" class="col-sm-3 col-form-label"></label>
     <div class="col-sm-9">
         <div class="input-group">
-            <label asp-for="CompetenciaAno" class="input-group-text"></label>
-            <input asp-for="CompetenciaAno" class="form-control" placeholder="Ano" />
-            <label asp-for="CompetenciaMes" class="input-group-text"></label>
-            <select asp-for="CompetenciaMes" class="form-select">
-                <option value="" disabled selected>Mês</option>
-                <option value="1">01 (janeiro)</option>
-                <option value="2">02 (fevereiro)</option>
-                <option value="3">03 (março)</option>
-                <option value="4">04 (abril)</option>
-                <option value="5">05 (maio)</option>
-                <option value="6">06 (junho)</option>
-                <option value="7">07 (julho)</option>
-                <option value="8">08 (agosto)</option>
-                <option value="9">09 (setembro)</option>
-                <option value="10">10 (outubro)</option>
-                <option value="11">11 (novembro)</option>
-                <option value="12">12 (dezembro)</option>
-            </select>
+            <input asp-for="Folha.Competencia" class="form-control" type="month" />
             <button class="btn btn-outline-secondary" name="command" value="ConfirmarCompetencia">Confirmar</button>
         </div>
-        <span asp-validation-for="CompetenciaAno" class="text-danger"></span>
-        <span asp-validation-for="CompetenciaMes" class="text-danger"></span>
+        <span asp-validation-for="Folha.Competencia" class="text-danger"></span>
     </div>
 </div>
 <div class="row mb-3">

--- a/src/MeuPonto.Web/Modules/Pontos/Folhas/Editar.cshtml
+++ b/src/MeuPonto.Web/Modules/Pontos/Folhas/Editar.cshtml
@@ -77,31 +77,13 @@
     </div>
 </div>
 <div class="row mb-3">
-    <span class="col-sm-3 col-form-label">Competência</span>
+    <label asp-for="Folha.Competencia" class="col-sm-3 col-form-label"></label>
     <div class="col-sm-9">
         <div class="input-group">
-            <label asp-for="CompetenciaAno" class="input-group-text"></label>
-            <input asp-for="CompetenciaAno" class="form-control" placeholder="Ano" />
-            <label asp-for="CompetenciaMes" class="input-group-text"></label>
-            <select asp-for="CompetenciaMes" class="form-select">
-                <option value="" disabled selected>Mês</option>
-                <option value="1">01 (janeiro)</option>
-                <option value="2">02 (fevereiro)</option>
-                <option value="3">03 (março)</option>
-                <option value="4">04 (abril)</option>
-                <option value="5">05 (maio)</option>
-                <option value="6">06 (junho)</option>
-                <option value="7">07 (julho)</option>
-                <option value="8">08 (agosto)</option>
-                <option value="9">09 (setembro)</option>
-                <option value="10">10 (outubro)</option>
-                <option value="11">11 (novembro)</option>
-                <option value="12">12 (dezembro)</option>
-            </select>
+            <input asp-for="Folha.Competencia" class="form-control" type="month" />
             <button class="btn btn-outline-secondary" name="command" value="ConfirmarCompetencia">Confirmar</button>
         </div>
-        <span asp-validation-for="CompetenciaAno" class="text-danger"></span>
-        <span asp-validation-for="CompetenciaMes" class="text-danger"></span>
+        <span asp-validation-for="Folha.Competencia" class="text-danger"></span>
     </div>
 </div>
 <div class="row mb-3">

--- a/src/MeuPonto.Web/Modules/Pontos/Folhas/Fechar.cshtml.cs
+++ b/src/MeuPonto.Web/Modules/Pontos/Folhas/Fechar.cshtml.cs
@@ -69,7 +69,7 @@ public class FecharFolhaModel : PageModel
             }
         }
 
-        return RedirectToPage("./Detalhar", new { id = Folha.Id });
+        return RedirectToPage("./Detalhar", new { id });
     }
 
     private async Task Apurar(Folha folha)

--- a/src/MeuPonto.Web/Modules/Shared/_Layout.cshtml
+++ b/src/MeuPonto.Web/Modules/Shared/_Layout.cshtml
@@ -104,7 +104,7 @@
 
             @if (IsSectionDefined("FormActions"))
             {
-                <form method="post">
+                <form method="post" enctype="@ViewData["Enctype"]">
                     @if (IsSectionDefined("CardHeader"))
                     {
                         <div class="card">

--- a/src/MeuPonto.WebApi/Models/Folha.cs
+++ b/src/MeuPonto.WebApi/Models/Folha.cs
@@ -16,7 +16,7 @@ public class Folha : GlobalTableEntity, Concepts.Folha
 
     [Required]
     [DisplayName("Competência")]
-    [DisplayFormat(DataFormatString = "{0:yyyy/MM (MMMM)}")]
+    [DisplayFormat(DataFormatString = "{0:y}")]
     public DateTime? Competencia { get; set; }
 
     [Required]


### PR DESCRIPTION
Ao invés de usar dois campos, um para o ano e outro para o mês, para formar uma competência, agora é usado apenas um campo do tipo DateTime.

Também corrige alguns testes que estavam quebrados.